### PR TITLE
Add http to https redirect rule for release builds

### DIFF
--- a/EquineExchange.ImageHosting/Web.Release.config
+++ b/EquineExchange.ImageHosting/Web.Release.config
@@ -1,31 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <!--
-    In the example below, the "SetAttributes" transform will change the value of 
-    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
-    finds an attribute "name" that has a value of "MyDB".
-    
-    <connectionStrings>
-      <add name="MyDB" 
-        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
-        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
-    </connectionStrings>
-  -->
-  <system.web>
-    <compilation xdt:Transform="RemoveAttributes(debug)" />
-    <!--
-      In the example below, the "Replace" transform will replace the entire 
-      <customErrors> section of your web.config file.
-      Note that because there is only one customErrors section under the 
-      <system.web> node, there is no need to use the "xdt:Locator" attribute.
-      
-      <customErrors defaultRedirect="GenericError.htm"
-        mode="RemoteOnly" xdt:Transform="Replace">
-        <error statusCode="500" redirect="InternalError.htm"/>
-      </customErrors>
-    -->
-  </system.web>
+    <system.web>
+        <compilation xdt:Transform="RemoveAttributes(debug)" />
+    </system.web>
+
+    <system.webServer>
+        <rewrite xdt:Transform="Insert">
+            <rules>
+                <rule name="Force HTTPS" stopProcessing="true">
+                    <match url="(.*)" ignoreCase="false" />
+                    <conditions>
+                        <add input="{HTTPS}" pattern="off" />
+                    </conditions>
+                    <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" appendQueryString="true" redirectType="Permanent" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
 </configuration>


### PR DESCRIPTION
We're going https by default since the default domain for azure app services has a wild card certificate (Let's Encrypt is also an extension/option if using a custom domain), and azure cdn includes free ssl certificates.