### PR TITLE
Use non-async module so caching works

### DIFF
--- a/EquineExchange.ImageHosting/Web.config
+++ b/EquineExchange.ImageHosting/Web.config
@@ -56,7 +56,7 @@
             <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
             <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
             <add name="ImageResizingConfig" type="EquineExchange.ImageHosting.ImageResizingConfig" />
-            <add name="ImageResizingModule" type="ImageResizer.AsyncInterceptModule" />
+            <add name="ImageResizingModule" type="ImageResizer.InterceptModule" />
         </modules>
     </system.webServer>
 


### PR DESCRIPTION
When using the `AsyncInterceptModule` caching headers aren't written out as they should be. Switching back to the non-async `InterceptModule` fixes that and the `cache-control` and `expires` headers are included in the response.