### PR TITLE
Add warmup & remote_addr conditions to https rule

### DIFF
--- a/EquineExchange.ImageHosting/Web.Release.config
+++ b/EquineExchange.ImageHosting/Web.Release.config
@@ -11,9 +11,11 @@
         <rewrite xdt:Transform="Insert">
             <rules>
                 <rule name="Force HTTPS" stopProcessing="true">
-                    <match url="(.*)" ignoreCase="false" />
+                    <match url="(.*)" ignoreCase="true" />
                     <conditions>
-                        <add input="{HTTPS}" pattern="off" />
+                        <add input="{WARMUP_REQUEST}" pattern="1" negate="true" />
+                        <add input="{REMOTE_ADDR}" pattern="^100?\." negate="true" />
+                        <add input="{HTTPS}" pattern="^OFF$" />
                     </conditions>
                     <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" appendQueryString="true" redirectType="Permanent" />
                 </rule>


### PR DESCRIPTION
These updates should allow warmup and always on requests to make it through. The change is based on feedback from http://ruslany.net/2017/11/most-common-deployment-slot-swap-failures-and-how-to-fix-them/