### PR TITLE
Remove https rewrite rule from release builds

### DIFF
--- a/EquineExchange.ImageHosting/Web.Release.config
+++ b/EquineExchange.ImageHosting/Web.Release.config
@@ -6,18 +6,4 @@
     <system.web>
         <compilation xdt:Transform="RemoveAttributes(debug)" />
     </system.web>
-
-    <system.webServer>
-        <rewrite xdt:Transform="Insert">
-            <rules>
-                <rule name="Force HTTPS" stopProcessing="true">
-                    <match url="(.*)" ignoreCase="false" />
-                    <conditions>
-                        <add input="{HTTPS}" pattern="off" />
-                    </conditions>
-                    <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" appendQueryString="true" redirectType="Permanent" />
-                </rule>
-            </rules>
-        </rewrite>
-    </system.webServer>
 </configuration>


### PR DESCRIPTION
There's a new setting on azure under `Custom Domains` called `HTTPS Only`. That's the preferred way to force https on a site now, so this rule is being removed in favor of the new setting.

This new setting happens on the front end server/load balancer so the extra hacks to allow the always on & slot warmup requests through are no longer needed.