### PR TITLE
Update AI Snapshot Collector to 1.2.1

### DIFF
--- a/EquineExchange.ImageHosting/ApplicationInsights.config
+++ b/EquineExchange.ImageHosting/ApplicationInsights.config
@@ -101,18 +101,18 @@
             <!-- Snapshot Debugging is usually disabled in developer mode, but you can enable it by setting this to true. -->
             <!-- DeveloperMode is a property on the active TelemetryChannel. Default: false -->
             <IsEnabledInDeveloperMode>false</IsEnabledInDeveloperMode>
-            <!-- How many times we need to see an exception before we ask for snapshots. Default: 5 -->
+            <!-- How many times we need to see an exception before we ask for snapshots. Default: 1 -->
             <ThresholdForSnapshotting>1</ThresholdForSnapshotting>
             <!-- The maximum number of snapshots we collect for a single problem. Default: 3 -->
             <MaximumSnapshotsRequired>3</MaximumSnapshotsRequired>
             <!-- The maximum number of problems that we can be tracking at any time. Default: 50 -->
             <MaximumCollectionPlanSize>50</MaximumCollectionPlanSize>
-            <!-- How often to reset problem counters. Default: 06:00:00 -->
-            <ProblemCounterResetInterval>06:00:00</ProblemCounterResetInterval>
-            <!-- The maximum number of snapshots allowed in one minute. Default: 2 -->
-            <SnapshotsPerMinuteLimit>2</SnapshotsPerMinuteLimit>
-            <!-- The maximum number of snapshots allowed per day. Default: 50 -->
-            <SnapshotsPerDayLimit>50</SnapshotsPerDayLimit>
+            <!-- How often to reset problem counters. Default: 24:00:00 -->
+            <ProblemCounterResetInterval>24:00:00</ProblemCounterResetInterval>
+            <!-- The maximum number of snapshots allowed per day. Default: 30 -->
+            <SnapshotsPerDayLimit>30</SnapshotsPerDayLimit>
+            <!--Whether or not to collect snapshot in low IO priority thread.Default: true -->
+            <SnapshotInLowPriorityThread>true</SnapshotInLowPriorityThread>
         </Add>
     </TelemetryProcessors>
     <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>

--- a/EquineExchange.ImageHosting/EquineExchange.ImageHosting.csproj
+++ b/EquineExchange.ImageHosting/EquineExchange.ImageHosting.csproj
@@ -80,8 +80,8 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.SnapshotCollector, Version=1.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.0.10\lib\net45\Microsoft.ApplicationInsights.SnapshotCollector.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights.SnapshotCollector, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.2.1\lib\net45\Microsoft.ApplicationInsights.SnapshotCollector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.0\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
@@ -186,9 +186,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.3.2\build\Microsoft.Net.Compilers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.0.10\build\Microsoft.ApplicationInsights.SnapshotCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.0.10\build\Microsoft.ApplicationInsights.SnapshotCollector.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.2.1\build\Microsoft.ApplicationInsights.SnapshotCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.2.1\build\Microsoft.ApplicationInsights.SnapshotCollector.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.0.10\build\Microsoft.ApplicationInsights.SnapshotCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.0.10\build\Microsoft.ApplicationInsights.SnapshotCollector.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.2.1\build\Microsoft.ApplicationInsights.SnapshotCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.SnapshotCollector.1.2.1\build\Microsoft.ApplicationInsights.SnapshotCollector.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EquineExchange.ImageHosting/packages.config
+++ b/EquineExchange.ImageHosting/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.1" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.0.10" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.2.1" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.Web" version="2.4.1" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net47" />


### PR DESCRIPTION
From Azure
>A recent Azure App Services platform update caused Snapshot Collector NuGet packages older than version 1.1.1 to no longer work. Please upgrade to keep automatically collecting a debug snapshot from your live web application when an exception occurs.
